### PR TITLE
feat: add progress and card attached to auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ export default function App() {
   const [isCardAttached, setIsCardAttached] = useState(false)
   const [progress, setProgress] = useState(0)
 
+  const [requestedAccessRights, setRequestedAccessRights] = useState<string[]>()
+  const [onAcceptAccessRights, setOnAcceptAccessRights] = useState<(accept: boolean) => void>()
+
   const cancelFlow = () =>
     flow
       ?.cancel()
@@ -193,6 +196,17 @@ export default function App() {
         },
         onCardAttachedChanged: ({ isCardAttached }) => setIsCardAttached(isCardAttached),
         onStatusProgress: ({ progress }) => setProgress(progress),
+        onRequestAccessRights: ({ effective }) =>
+          new Promise((resolve) => {
+            setRequestedAccessRights(effective)
+            setOnAcceptAccessRights(() => {
+              return (accept: boolean) => {
+                resolve({ acceptAccessRights: accept })
+                setOnAcceptAccessRights(undefined)
+                setRequestedAccessRights(undefined)
+              }
+            })
+          }),
       }).start({
         tcTokenUrl: 'https://test.governikus-eid.de/AusweisAuskunft/WebServiceRequesterServlet',
       })
@@ -205,6 +219,16 @@ export default function App() {
       {flow && <Text>Progress: {progress}%</Text>}
       {flow && <Text>Is card attached: {isCardAttached ? 'Yes' : 'No'}</Text>}
       {flow && cardAttachRequested && <Text>Please present your card to the NFC scanner</Text>}
+      {flow && requestedAccessRights && (
+        <>
+          <Text>
+            Requested Access Rights:
+            {'\n -'}
+            {requestedAccessRights.join('\n- ')}
+          </Text>
+          <Button title="Accept" onPress={() => onAcceptAccessRights?.(true)} />
+        </>
+      )}
       {message && <Text>{message}</Text>}
     </View>
   )

--- a/README.md
+++ b/README.md
@@ -149,12 +149,15 @@ Note that this class is optimized for a simple auth flow and thus it may not fit
 ```tsx
 import { AusweisAuthFlow } from '@animo-id/expo-ausweis-sdk'
 import { useState } from 'react'
-import { Button } from 'react-native'
-import { StyleSheet, Text, View } from 'react-native'
+import { Button, StyleSheet, Text, View } from 'react-native'
 
 export default function App() {
   const [message, setMessage] = useState<string>()
   const [flow, setFlow] = useState<AusweisAuthFlow>()
+
+  const [cardAttachRequested, setCardAttachRequested] = useState(false)
+  const [isCardAttached, setIsCardAttached] = useState(false)
+  const [progress, setProgress] = useState(0)
 
   const cancelFlow = () =>
     flow
@@ -166,23 +169,30 @@ export default function App() {
     setMessage(undefined)
     setFlow(
       new AusweisAuthFlow({
+        debug: true,
         onEnterPin: ({ attemptsRemaining }) => {
           // Mock incorrect pin entry
           return attemptsRemaining === 1 ? '123456' : '123123'
         },
         onError: ({ message, reason }) => {
           setFlow(undefined)
+          setCardAttachRequested(false)
+          setProgress(0)
           setMessage(`${reason}: ${message}`)
         },
         onSuccess: () => {
           setFlow(undefined)
+          setProgress(100)
+          setCardAttachRequested(false)
           setMessage('Successfully ran auth flow')
         },
-        onInsertCard: () => {
-          // For iOS this will show the NFC scanner modal. on Android we need
+        onAttachCard: () => {
+          // iOS will already show the NFC scanner modal, but on Android we need
           // use this callback to show the NFC scanner modal.
-          console.log('please insert card')
+          setCardAttachRequested(true)
         },
+        onCardAttachedChanged: ({ isCardAttached }) => setIsCardAttached(isCardAttached),
+        onStatusProgress: ({ progress }) => setProgress(progress),
       }).start({
         tcTokenUrl: 'https://test.governikus-eid.de/AusweisAuskunft/WebServiceRequesterServlet',
       })
@@ -192,6 +202,9 @@ export default function App() {
   return (
     <View style={[StyleSheet.absoluteFill, { flex: 1, alignContent: 'center', justifyContent: 'center' }]}>
       <Button onPress={flow ? cancelFlow : runAuthFlow} title={flow ? 'Cancel' : 'Start Auth Flow'} />
+      {flow && <Text>Progress: {progress}%</Text>}
+      {flow && <Text>Is card attached: {isCardAttached ? 'Yes' : 'No'}</Text>}
+      {flow && cardAttachRequested && <Text>Please present your card to the NFC scanner</Text>}
       {message && <Text>{message}</Text>}
     </View>
   )


### PR DESCRIPTION
three new features for auth flow:
- get notified when card is attached/detached
- get notified of progress in percentage, ausweis sdk emits at 20,40,60,80 its seems
- allow passing a onRequestAccessrRights callback so the user can accept access rights (required to be presented to user according to german law)